### PR TITLE
Add Apple Silicon MPS training support and small-dataset tooling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea/
 .vscode/
 .gitignore
+venv/
+data/
+runs/
+agent/history/

--- a/configs/mac_test_mobilenet_v4_m_mps.yaml
+++ b/configs/mac_test_mobilenet_v4_m_mps.yaml
@@ -1,0 +1,21 @@
+# Smoke test: MobileNetV4 on a synthetic dataset, Apple MPS (M4 Pro).
+# Prep:  python tools/create_minimal_dataset.py
+# Run:   python train.py --cfg configs/mac_test_mobilenet_v4_m_mps.yaml
+
+train: data/minimal_test/train
+val: data/minimal_test/valid
+save_path: runs/rfuav_subset_mps_mobilenet_v4
+
+model: mobilenet_v4_medium
+weights: None
+batch_size: 4
+image_size: 224
+num_classes: 2
+class_names:
+  - class_a
+  - class_b
+device: mps
+num_epochs: 2
+shuffle: true
+lr: 0.0001
+optimizer: None

--- a/configs/mac_test_resnet18_cpu.yaml
+++ b/configs/mac_test_resnet18_cpu.yaml
@@ -1,0 +1,21 @@
+# Smoke test: ResNet18 on a synthetic dataset, CPU.
+# Prep:  python tools/create_minimal_dataset.py
+# Run:   python train.py --cfg configs/mac_test_resnet18_cpu.yaml
+
+train: data/minimal_test/train
+val: data/minimal_test/valid
+save_path: runs/minimal_test_cpu
+
+model: resnet18
+weights: None
+batch_size: 4
+image_size: 224
+num_classes: 2
+class_names:
+  - class_a
+  - class_b
+device: cpu
+num_epochs: 2
+shuffle: true
+lr: 0.0001
+optimizer: None

--- a/configs/mac_test_resnet18_hf.yaml
+++ b/configs/mac_test_resnet18_hf.yaml
@@ -1,0 +1,23 @@
+# Train ResNet18 on an RFUAV subset from Hugging Face.
+# Prep:  python tools/download_dataset.py --classes "DJI AVATA2" "DJI MINI4 PRO" --max-per-class 50
+# Run:   python train.py --cfg configs/mac_test_resnet18_hf.yaml
+#
+# class_names must match the folder names under data/rfuav_subset/.
+
+train: data/rfuav_subset/train
+val: data/rfuav_subset/valid
+save_path: runs/rfuav_subset_mps
+
+model: resnet18
+weights: None
+batch_size: 8
+image_size: 224
+num_classes: 2
+class_names:
+  - DJI AVATA2
+  - DJI MINI4 PRO
+device: mps
+num_epochs: 5
+shuffle: true
+lr: 0.0001
+optimizer: None

--- a/configs/mac_test_resnet18_mps.yaml
+++ b/configs/mac_test_resnet18_mps.yaml
@@ -1,0 +1,21 @@
+# Smoke test: ResNet18 on a synthetic dataset, Apple MPS (M4 Pro).
+# Prep:  python tools/create_minimal_dataset.py
+# Run:   python train.py --cfg configs/mac_test_resnet18_mps.yaml
+
+train: data/minimal_test/train
+val: data/minimal_test/valid
+save_path: runs/minimal_test_mps
+
+model: resnet18
+weights: None
+batch_size: 4
+image_size: 224
+num_classes: 2
+class_names:
+  - class_a
+  - class_b
+device: mps
+num_epochs: 2
+shuffle: true
+lr: 0.0001
+optimizer: None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python >= 3.9
+#python >= 3.9
 opencv-python >= 4.9.0.80
 numpy >= 1.24.4
 matplotlib >= 3.9.2
@@ -21,4 +21,8 @@ torch >= 2.0.1
 torchvision >= 0.15.2
 torchaudio >=2.0.2
 
+timm==1.0.27
+
 albumentations >= 1.4.20
+huggingface_hub >= 0.26.0
+requests >= 2.32.0

--- a/tools/create_minimal_dataset.py
+++ b/tools/create_minimal_dataset.py
@@ -1,0 +1,95 @@
+"""
+Synthetic dataset generator for training-pipeline smoke tests.
+
+Creates a minimal folder layout compatible with ImageFolder:
+
+    <output>/
+        train/class_a/*.png
+        train/class_b/*.png
+        valid/class_a/*.png
+        valid/class_b/*.png
+
+Images are solid RGB fills with class-dependent hues.
+That is enough to exercise data loading, forward/backward passes,
+checkpoint saving, and device selection (CPU/MPS).
+
+Used by:
+- configs/mac_test_resnet18_cpu.yaml
+- configs/mac_test_resnet18_mps.yaml
+
+Example:
+    python tools/create_minimal_dataset.py --output data/minimal_test
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+def create_class_images(class_dir: Path, class_idx: int, count: int, size: int = 224) -> None:
+    """
+    Create a series of PNG images for a single class.
+
+    Colors depend on the class index and sample number so classes
+    remain linearly separable even without augmentations.
+
+    Args:
+        class_dir: Class folder (created if missing).
+        class_idx: Numeric class index (0, 1, ...).
+        count: Number of images to create.
+        size: Side length of the square image in pixels.
+    """
+    class_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        base = (class_idx * 40) % 255
+        image = np.zeros((size, size, 3), dtype=np.uint8)
+        image[:, :, 0] = base
+        image[:, :, 1] = (base + i * 10) % 255
+        image[:, :, 2] = (base + class_idx * 25) % 255
+        Image.fromarray(image).save(class_dir / f"sample_{i:03d}.png")
+
+
+def create_minimal_dataset(output_dir: str, train_per_class: int = 8, val_per_class: int = 4) -> None:
+    """
+    Create a complete minimal dataset with two classes.
+
+    Args:
+        output_dir: Dataset root directory.
+        train_per_class: Number of train images per class.
+        val_per_class: Number of valid images per class.
+    """
+    root = Path(output_dir)
+    classes = ["class_a", "class_b"]
+
+    for split, count in (("train", train_per_class), ("valid", val_per_class)):
+        for class_idx, class_name in enumerate(classes):
+            create_class_images(root / split / class_name, class_idx, count)
+
+    print(f"Dataset created at: {root.resolve()}")
+    print(f"Classes: {', '.join(classes)}")
+    print(f"Train images per class: {train_per_class}")
+    print(f"Valid images per class: {val_per_class}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a minimal RFUAV test dataset")
+    parser.add_argument(
+        "--output",
+        default="data/minimal_test",
+        help="Output dataset directory",
+    )
+    parser.add_argument("--train-per-class", type=int, default=8)
+    parser.add_argument("--val-per-class", type=int, default=4)
+    args = parser.parse_args()
+
+    create_minimal_dataset(
+        output_dir=args.output,
+        train_per_class=args.train_per_class,
+        val_per_class=args.val_per_class,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/download_dataset.py
+++ b/tools/download_dataset.py
@@ -1,0 +1,107 @@
+"""
+CLI for selective RFUAV dataset download from Hugging Face.
+
+Examples:
+
+    # List all available classes (37)
+    python tools/download_dataset.py --list-classes
+
+    # Download 2 classes, 50 images per split
+    python tools/download_dataset.py \\
+        --classes "DJI AVATA2" "DJI MINI4 PRO" \\
+        --max-per-class 50 \\
+        --output data/rfuav_subset
+
+    # Train split only
+    python tools/download_dataset.py \\
+        --classes "DJI AVATA2" \\
+        --split train \\
+        --max-per-class 100
+
+After download, the layout is ready for `CustomTrainer` and `ImageFolder`.
+See also `configs/mac_test_resnet18_hf.yaml`.
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Put the project root on sys.path so this script can be run directly.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from utils.hf_dataset import (  # noqa: E402
+    DEFAULT_IMAGE_SET,
+    download_subset,
+    list_available_classes,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Download a subset of kitofrank/RFUAV from Hugging Face",
+    )
+    parser.add_argument(
+        "--output",
+        default="data/rfuav_subset",
+        help="Output directory with train/ and valid/ folders",
+    )
+    parser.add_argument(
+        "--classes",
+        nargs="+",
+        help="Drone class names to download (default: all available classes)",
+    )
+    parser.add_argument(
+        "--max-per-class",
+        type=int,
+        help="Maximum number of images per class in each split",
+    )
+    parser.add_argument(
+        "--split",
+        choices=["train", "valid", "both"],
+        default="both",
+        help="Which dataset split(s) to download",
+    )
+    parser.add_argument(
+        "--image-set",
+        default=DEFAULT_IMAGE_SET,
+        help="Image set prefix inside the Hugging Face repository",
+    )
+    parser.add_argument(
+        "--list-classes",
+        action="store_true",
+        help="Print available class names and exit",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point: list classes or start a download."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    if args.list_classes:
+        for class_name in list_available_classes(image_set=args.image_set):
+            print(class_name)
+        return
+
+    splits = ("train", "valid") if args.split == "both" else (args.split,)
+    summary = download_subset(
+        output_dir=args.output,
+        classes=args.classes,
+        max_per_class=args.max_per_class,
+        splits=splits,
+        image_set=args.image_set,
+    )
+
+    print(f"Dataset saved to: {summary['output_dir']}")
+    print(f"Classes: {len(summary['classes'])}")
+    for class_name, split_counts in summary["files"].items():
+        counts = ", ".join(f"{split}={count}" for split, count in split_counts.items())
+        print(f"  - {class_name}: {counts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -1,19 +1,70 @@
-# A script to train the detect model and classification model on spectrogram image.
+"""
+Entry point for RFUAV model training.
+
+Supports two modes:
+- classify — spectrogram classification (ResNet, ViT, etc.) via a YAML config
+- detect   — detection with YOLOv5
+
+Examples:
+
+    # CPU smoke test (synthetic dataset)
+    python tools/create_minimal_dataset.py
+    mkdir -p runs/minimal_test_cpu
+    python train.py --cfg configs/mac_test_resnet18_cpu.yaml
+
+    # Training on a Hugging Face subset
+    python tools/download_dataset.py --classes "DJI AVATA2" --max-per-class 50
+    mkdir -p runs/rfuav_subset_mps
+    python train.py --cfg configs/mac_test_resnet18_hf.yaml
+
+    # Detection (YOLO)
+    python train.py --mode detect --save-dir runs/yolo --dataset-dir path/to/data
+"""
+import argparse
+
 from utils.trainer import CustomTrainer
 from utils.trainer import DetTrainer
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Train RFUAV classification or detection model")
+    parser.add_argument(
+        "--cfg",
+        default="",
+        help="Path to classification YAML config (e.g. configs/mac_test_resnet18_cpu.yaml)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["classify", "detect"],
+        default="classify",
+        help="Training mode",
+    )
+    parser.add_argument(
+        "--save-dir",
+        default="",
+        help="Output directory for detection training",
+    )
+    parser.add_argument(
+        "--dataset-dir",
+        default="",
+        help="Dataset directory for detection training",
+    )
+    args = parser.parse_args()
 
-    # classification Trainer
-    model = CustomTrainer(cfg='')
-    model.train()
+    if args.mode == "classify":
+        if not args.cfg:
+            raise ValueError("Classification training requires --cfg")
+        trainer = CustomTrainer(cfg=args.cfg)
+        trainer.train()
+        return
 
-    # Detection Trainer
-    save_dir = ''
-    model = DetTrainer(model_name='yolo', dataset_dir = '')
+    save_dir = args.save_dir
+    if not save_dir:
+        raise ValueError("Detection training requires --save-dir")
+
+    model = DetTrainer(model_name="yolo", dataset_dir=args.dataset_dir)
     model.train(save_dir=save_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/utils/build.py
+++ b/utils/build.py
@@ -1,16 +1,24 @@
-"""build from CFG
+"""
+Load and validate training YAML configs.
+
+`check_cfg()` verifies data paths, class-count consistency, and resolves
+the device via `resolve_device()` — so configs may specify `cpu`, `cuda`,
+or `mps`, and the value is corrected when the requested backend is
+unavailable.
 """
 import yaml
 import logging
 import os
 import torch
 
+from utils.device import resolve_device
+
 DefaultConfig = '../configs/config.yaml'
 Model_list = [
     "resnet18", "resnet34", "resnet50", "resnet101", "resnet152",
     "vit_b_16", "vit_b_32", "vit_l_16", "vit_l_32", "vit_h_14",
     "swin_v2_t", "swin_v2_s", "swin_v2_b", "mobilenet_v3_small",
-    "mobilenet_v3_large"]
+    "mobilenet_v3_large", "mobilenet_v4_medium"]
 
 
 def check_cfg(cfg: str):
@@ -31,9 +39,11 @@ def check_cfg(cfg: str):
     if opt['weights'] == None or not os.path.exists(opt['weights']):
         logging.info("No pretrained weights specified, training from scratch")
         opt['pretrained'] = False
-    if opt['device'] != 'cpu' and not torch.cuda.is_available():
-        logging.info("CUDA is not available, using CPU instead")
-        opt['device'] = "cpu"
+    # Normalize device to a valid torch.device string (cpu/cuda/mps).
+    resolved = resolve_device(opt['device'])
+    if str(resolved) != str(opt['device']).strip().lower():
+        logging.info("Requested device '%s', using '%s' instead", opt['device'], resolved)
+    opt['device'] = str(resolved)
     return True
 
 

--- a/utils/device.py
+++ b/utils/device.py
@@ -1,0 +1,66 @@
+"""
+Compute-device selection for training and inference.
+
+Centralizes PyTorch backend selection:
+- CUDA (NVIDIA GPU)
+- MPS  (Apple Metal Performance Shaders — GPU/NPU on Apple Silicon Macs)
+- CPU  (fallback when the requested backend is unavailable)
+
+Used by `utils.build.check_cfg()` and `utils.trainer.Basetrainer`.
+The `device` value from a YAML config passes through `resolve_device()`
+before a `torch.device` is created, so configs may specify `cpu`, `cuda`,
+`mps`, or `cuda:0`.
+"""
+
+import logging
+
+import torch
+
+
+def mps_is_available() -> bool:
+    """
+    Check whether Apple MPS is available in the current PyTorch install.
+
+    Returns:
+        True if `torch.backends.mps` exists and MPS is available.
+    """
+    return bool(
+        getattr(torch.backends, "mps", None)
+        and torch.backends.mps.is_available()
+    )
+
+
+def resolve_device(device: str = "cuda") -> torch.device:
+    """
+    Convert a string device identifier into a `torch.device`.
+
+    Resolution order:
+    1. CUDA — if `cuda`/`gpu`/`cuda:N` is requested and a GPU is available.
+    2. MPS  — if `mps` is requested and the Apple Silicon backend is available.
+    3. CPU  — in all other cases (including an unavailable backend).
+
+    Args:
+        device: Value from a config or CLI argument. Supported values:
+            `cpu`, `cuda`, `cuda:0`, `gpu`, `mps`.
+
+    Returns:
+        A `torch.device` ready to pass to `model.to(device)`.
+    """
+    requested = str(device).strip().lower()
+
+    # NVIDIA GPU: prefer when CUDA is explicitly requested and available.
+    if requested in ("cuda", "gpu") or requested.startswith("cuda:"):
+        if torch.cuda.is_available():
+            return torch.device(requested if requested.startswith("cuda:") else "cuda")
+        logging.warning("CUDA requested but not available, falling back")
+
+    # Apple Silicon: Metal Performance Shaders (M4 Pro and similar).
+    if requested == "mps":
+        if mps_is_available():
+            return torch.device("mps")
+        logging.warning("MPS requested but not available, falling back to CPU")
+
+    if requested not in ("cpu", "cuda", "mps", "gpu") and not requested.startswith("cuda:"):
+        logging.warning("Unknown device '%s', falling back to CPU", device)
+
+    return torch.device("cpu")

--- a/utils/hf_dataset.py
+++ b/utils/hf_dataset.py
@@ -1,0 +1,218 @@
+"""
+Selective RFUAV dataset download from Hugging Face.
+
+Repository: https://huggingface.co/datasets/kitofrank/RFUAV
+
+Classification spectrograms live under
+`ImageSet-AllDrones-MatlabPipeline` with the layout:
+
+    ImageSet-AllDrones-MatlabPipeline/
+        train/<class_name>/*.jpg
+        valid/<class_name>/*.jpg
+
+After download, files are arranged in an ImageFolder-compatible layout
+expected by the project trainer:
+
+    <output_dir>/
+        train/<class_name>/*.jpg
+        valid/<class_name>/*.jpg
+        download_manifest.json
+
+The manifest records which classes and how many files were downloaded.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import Sequence
+
+from huggingface_hub import hf_hub_download, list_repo_files
+
+# Hugging Face Hub dataset identifier.
+REPO_ID = "kitofrank/RFUAV"
+
+# Repository subset with spectrograms (Matlab pipeline).
+DEFAULT_IMAGE_SET = "ImageSet-AllDrones-MatlabPipeline"
+
+# Allowed image extensions when filtering repository files.
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png")
+
+# Splits supported by this image set.
+SPLITS = ("train", "valid")
+
+
+def _available_classes_from_repo_files(
+    repo_files: Sequence[str],
+    image_set: str = DEFAULT_IMAGE_SET,
+) -> list[str]:
+    """
+    Extract class names from an already-fetched repository file list.
+
+    Parses paths of the form `<image_set>/<split>/<class_name>/<file>.jpg`.
+    Keeping this separate avoids re-listing files inside `download_subset()`.
+
+    Args:
+        repo_files: Full list of file paths from `list_repo_files()`.
+        image_set: Image-set prefix inside the repository.
+
+    Returns:
+        Sorted list of unique class names.
+    """
+    classes: set[str] = set()
+    prefix = f"{image_set}/"
+    for path in repo_files:
+        if not path.startswith(prefix):
+            continue
+        parts = Path(path).parts
+        if len(parts) < 4:
+            continue
+        split, class_name = parts[1], parts[2]
+        if split in SPLITS and Path(path).suffix.lower() in IMAGE_EXTENSIONS:
+            classes.add(class_name)
+    return sorted(classes)
+
+
+def list_available_classes(
+    image_set: str = DEFAULT_IMAGE_SET,
+    repo_id: str = REPO_ID,
+) -> list[str]:
+    """
+    Return all classes available in the given Hugging Face image set.
+
+    Performs a network request to the Hub API (~7 s for the full RFUAV repo).
+
+    Args:
+        image_set: Image-set prefix (defaults to the Matlab pipeline).
+        repo_id: Hugging Face dataset ID.
+
+    Returns:
+        Sorted list of class names (37 for DEFAULT_IMAGE_SET).
+    """
+    return _available_classes_from_repo_files(
+        list_repo_files(repo_id, repo_type="dataset"),
+        image_set=image_set,
+    )
+
+
+def _class_files(
+    class_name: str,
+    split: str,
+    image_set: str,
+    repo_files: Sequence[str],
+) -> list[str]:
+    """
+    Filter repository files for a specific class and split.
+
+    Args:
+        class_name: Class name (must match the Hub folder name).
+        split: `train` or `valid`.
+        image_set: Image-set prefix.
+        repo_files: Cached list of all repository files.
+
+    Returns:
+        Sorted relative paths of image files.
+    """
+    prefix = f"{image_set}/{split}/{class_name}/"
+    return sorted(
+        path
+        for path in repo_files
+        if path.startswith(prefix) and Path(path).suffix.lower() in IMAGE_EXTENSIONS
+    )
+
+
+def download_subset(
+    output_dir: str | Path,
+    classes: Sequence[str] | None = None,
+    max_per_class: int | None = None,
+    splits: Sequence[str] = SPLITS,
+    image_set: str = DEFAULT_IMAGE_SET,
+    repo_id: str = REPO_ID,
+) -> dict:
+    """
+    Download selected spectrograms and arrange them for training.
+
+    Files are fetched via `hf_hub_download` into the local Hub cache,
+    then copied into `output_dir` with a flat train/valid layout.
+    Re-running updates/overwrites files with the same names.
+
+    Args:
+        output_dir: Root folder for the resulting dataset.
+        classes: Classes to download. None means all available classes.
+        max_per_class: Max images per class in each split.
+            None downloads every file for the class.
+        splits: Which splits to download (`train`, `valid`, or both).
+        image_set: Subdirectory inside the HF repository.
+        repo_id: Hugging Face dataset ID.
+
+    Returns:
+        Manifest dict with `classes`, `files`, `output_dir`, and related fields.
+        Also written to `output_dir/download_manifest.json`.
+
+    Raises:
+        ValueError: If an unknown class or unsupported split is requested.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # One repository file-list request for the entire download.
+    repo_files = list_repo_files(repo_id, repo_type="dataset")
+    available_classes = _available_classes_from_repo_files(repo_files, image_set=image_set)
+
+    if classes:
+        requested = list(classes)
+        missing = sorted(set(requested) - set(available_classes))
+        if missing:
+            raise ValueError(
+                "Unknown classes: "
+                + ", ".join(missing)
+                + ". Use --list-classes to see available class names."
+            )
+        selected_classes = requested
+    else:
+        selected_classes = available_classes
+
+    summary = {
+        "repo_id": repo_id,
+        "image_set": image_set,
+        "output_dir": str(output_path.resolve()),
+        "classes": selected_classes,
+        "splits": list(splits),
+        "max_per_class": max_per_class,
+        "files": {},
+    }
+
+    for class_name in selected_classes:
+        summary["files"][class_name] = {}
+        for split in splits:
+            if split not in SPLITS:
+                raise ValueError(f"Unsupported split '{split}'. Use: {', '.join(SPLITS)}")
+
+            files = _class_files(class_name, split, image_set, repo_files)
+            if max_per_class is not None:
+                # Take the first N files in lexicographic order.
+                files = files[:max_per_class]
+
+            split_dir = output_path / split / class_name
+            split_dir.mkdir(parents=True, exist_ok=True)
+            downloaded = 0
+
+            for remote_path in files:
+                # hf_hub_download stores the file under ~/.cache/huggingface/hub/.
+                local_file = hf_hub_download(
+                    repo_id=repo_id,
+                    repo_type="dataset",
+                    filename=remote_path,
+                )
+                destination = split_dir / Path(remote_path).name
+                shutil.copy2(local_file, destination)
+                downloaded += 1
+
+            summary["files"][class_name][split] = downloaded
+            logging.info("Downloaded %s/%s: %d files", split, class_name, downloaded)
+
+    manifest_path = output_path / "download_manifest.json"
+    manifest_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    return summary

--- a/utils/metrics/base_metric.py
+++ b/utils/metrics/base_metric.py
@@ -158,7 +158,11 @@ class EVAMetric:
 
         from topk import Accuracy
         print('start computing the Top-k')
-        acc = Accuracy(topk=(1, 2, 3))
+        default_topk = topk or (1, 2, 3)
+        # Top-k requires k <= num_classes; otherwise torch.topk fails on small datasets.
+        if num_classes is not None:
+            default_topk = tuple(k for k in default_topk if k <= num_classes) or (1,)
+        acc = Accuracy(topk=default_topk)
         res['Top-k'] = acc(preds, labels)
 
         return res

--- a/utils/trainer.py
+++ b/utils/trainer.py
@@ -7,9 +7,11 @@ import torch
 import torch.nn as nn
 from torchvision import models
 import torch.optim as optim
+import timm
 import os
 import yaml
 from utils.build import build_from_cfg, check_cfg
+from utils.device import resolve_device
 from utils.logger import colorful_logger
 import cv2
 from abc import abstractmethod
@@ -60,7 +62,8 @@ class Basetrainer:
     - save_path (str): Path to save the model
     - weight_path (str, optional): Path to pre-trained weights, default is None
     - log_file (str, optional): Path to the log file, default is "train.log"
-    - device (str, optional): Device to use, "cuda" or "cpu", default is "cuda"
+    - device (str, optional): Device to use: "cuda", "cpu" or "mps" (Apple Silicon).
+        Resolved via `utils.device.resolve_device()`. Default is "cuda".
     - criterion (torch.nn.Module, optional): Loss function, default is `nn.CrossEntropyLoss()`
     - pretrained (bool, optional): Whether to use pre-trained model, default is `True`
     - batch_size (int, optional): Batch size, default is 8
@@ -95,7 +98,8 @@ class Basetrainer:
         self.best_loss = 1e6
         self.best_epoch = 0
         self.best_model = None
-        self.device = torch.device(device if torch.cuda.is_available() else "cpu")
+        # CUDA, Apple MPS, and CPU with automatic fallback.
+        self.device = resolve_device(device)
         self.lr = lr
         self.logger = self.set_logger(os.path.join(save_path, log_file))
         self.criterion = criterion  # initializing the loss function
@@ -321,6 +325,11 @@ def model_init_(model_name, num_class, pretrained=True):
         model.head = nn.Linear(model.head.in_features, num_class)
 
     # Mobilenet series model
+    elif model_name == "mobilenet_v4_medium":
+        model = timm.create_model(
+            'mobilenetv4_conv_medium.e500_r224_in1k',
+            pretrained = True,
+            num_classes = num_class)
     elif model_name == "mobilenet_v3_large":
         model = models.mobilenet_v3_large(pretrained=pretrained)
         model.classifier = nn.Sequential(
@@ -673,8 +682,14 @@ class CustomTrainer(Basetrainer):
             yaml.dump(self.parameters, file, allow_unicode=True)
         return True
 
-    @property
     def train(self):
+        """
+        Run the training loop using parameters from the YAML config.
+
+        Important: this is a regular method, not a property. The previous
+        `@property` broke `trainer.train()` from `train.py`
+        (TypeError: NoneType not callable).
+        """
         num_epochs = self.parameters['num_epochs']
 
         for epoch in range(num_epochs):


### PR DESCRIPTION
- Fix requirements.txt packaging and add timm / huggingface_hub / requests deps
- Ignore venv/, data/, runs/, and agent/history/ in .gitignore
- Add utils/device.py with CUDA / MPS / CPU device resolution and fallback
- Wire MPS-aware device selection into build/check_cfg and Basetrainer
- Fix CustomTrainer.train by removing incorrect @property decorator
- Cap Top-k metrics to num_classes to avoid crashes on small datasets
- Add Hugging Face partial dataset download (tools/download_dataset.py, utils/hf_dataset.py)
- Add minimal synthetic dataset generator (tools/create_minimal_dataset.py)
- Add CLI args to train.py for classify/detect modes and YAML configs
- Add Mac smoke-test configs for ResNet18 (CPU/MPS/HF) and MobileNetV4 (MPS)
- Add MobileNetV4 medium (timm) model support in trainer/build